### PR TITLE
Unwraps and cleanup

### DIFF
--- a/src/bin/bu.rs
+++ b/src/bin/bu.rs
@@ -1,15 +1,18 @@
 use aws_sdk_s3::Client;
 
 use clap::Parser;
+use color_eyre::Result;
 use dialoguer::Confirm;
 use tokio::runtime::Runtime;
-use color_eyre::{Result};
-use tools::{log::setup_logging, s3::{size::CSVSizeReport, types::S3Location, wrapper::S3Wrapper}};
+use tools::{
+    log::setup_logging,
+    s3::{size::CSVSizeReport, types::S3Location, wrapper::S3Wrapper},
+};
 
 #[derive(Parser)]
 #[command(version, about)]
-/// Utility to support working with object versions in S3 
-struct Cli{
+/// Utility to support working with object versions in S3
+struct Cli {
     /// Verbose mode (-v, -vv, -vvv)
     #[clap(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
@@ -19,29 +22,35 @@ struct Cli{
 }
 
 #[derive(Parser)]
-enum Command{
+enum Command {
     #[clap(name = "size", about = "Report on a single bucket/prefix to console")]
-    Size{
+    Size {
         /// S3 URL
         #[clap(required = true)]
         url: String,
     },
-    #[clap(name = "size-report", about = "Report on a multiple buckets/prefixes to CSV")]
-    SizeReport{
+    #[clap(
+        name = "size-report",
+        about = "Report on a multiple buckets/prefixes to CSV"
+    )]
+    SizeReport {
         /// Comma separated S3 URLs
         #[clap(required = true, value_delimiter = ',', num_args = 1..)]
         urls: Vec<String>,
 
         /// CSV output file
-        #[clap(short, long, default_value="bucket_usage.csv")]
+        #[clap(short, long, default_value = "bucket_usage.csv")]
         out_file: String,
     },
-    #[clap(name = "destroy", about = "Delete all objects and versions under bucket/prefix")]
-    Destroy{
+    #[clap(
+        name = "destroy",
+        about = "Delete all objects and versions under bucket/prefix"
+    )]
+    Destroy {
         /// S3 URL to purge all objects and versions from
         #[arg(required = true)]
-        url: String
-    }
+        url: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -52,21 +61,29 @@ fn main() -> Result<()> {
     runtime.block_on(async {
         let config = aws_config::load_from_env().await;
 
-        let s3 = S3Wrapper{
+        let s3 = S3Wrapper {
             client: Client::new(&config),
         };
 
         match cli.command {
             Command::Destroy { url } => {
                 if Confirm::new()
-                    .with_prompt(format!(" Are you sure you want to destroy all objects and versions under {}?", url))
+                    .with_prompt(format!(
+                        " Are you sure you want to destroy all objects and versions under {}?",
+                        url
+                    ))
                     .default(false)
                     .interact()
-                    .expect("Interaction error") {
-
+                    .expect("Interaction error")
+                {
                     println!("*** Action confirmed ");
                     let s3_location = S3Location::parse(&url)?;
-                    s3.purge_all_versions_of_everything(&s3_location.bucket, &s3_location.prefix, true).await?
+                    s3.purge_all_versions_of_everything(
+                        &s3_location.bucket,
+                        &s3_location.prefix,
+                        true,
+                    )
+                    .await?
                 } else {
                     println!("*** Action dismissed")
                 }
@@ -75,28 +92,30 @@ fn main() -> Result<()> {
                 let s3_location = S3Location::parse(&url)?;
                 log::info!("Analysing: {}", &s3_location);
                 let report = tools::s3::size::build_size_report(&s3_location, &s3, true).await?;
-                println!("{}", report);    
-            },
+                println!("{}", report);
+            }
             Command::SizeReport { urls, out_file } => {
-                let urls = urls.iter().map(|u|S3Location::parse(u)).collect::<Result<Vec<S3Location>>>()?;
-                
+                let urls = urls
+                    .iter()
+                    .map(|u| S3Location::parse(u))
+                    .collect::<Result<Vec<S3Location>>>()?;
+
                 //Quick check to fail fast if we don't have access
                 for url in &urls {
                     log::info!("Check access for {}", url);
                     let versioning_enabled = s3.is_versioning_enabled(&url.bucket).await?;
                     log::info!(" - version check result: {}", versioning_enabled);
                 }
-                
+
                 let mut writer = csv::Writer::from_path(&out_file)?;
                 for url in &urls {
                     log::info!("Analysing: {}", url);
                     let report = tools::s3::size::build_size_report(url, &s3, true).await?;
-                    println!("Writing to {}: {}", &out_file, report);  
+                    println!("Writing to {}: {}", &out_file, report);
                     writer.serialize::<CSVSizeReport>((&report).into())?;
                     writer.flush()?;
                 }
-                
-            },
+            }
         };
 
         Ok(())

--- a/src/bin/bu.rs
+++ b/src/bin/bu.rs
@@ -46,8 +46,8 @@ enum Command{
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
-    setup_logging(cli.verbose);
-    let runtime = Runtime::new().unwrap();
+    setup_logging(cli.verbose)?;
+    let runtime = Runtime::new()?;
 
     runtime.block_on(async {
         let config = aws_config::load_from_env().await;

--- a/src/bin/bu.rs
+++ b/src/bin/bu.rs
@@ -1,7 +1,7 @@
 use aws_sdk_s3::Client;
 
 use clap::Parser;
-use color_eyre::Result;
+use color_eyre::{Result, eyre::Context};
 use dialoguer::Confirm;
 use tokio::runtime::Runtime;
 use tools::{
@@ -73,8 +73,7 @@ fn main() -> Result<()> {
                         url
                     ))
                     .default(false)
-                    .interact()
-                    .expect("Interaction error")
+                    .interact().wrap_err("Interaction error")?
                 {
                     println!("*** Action confirmed ");
                     let s3_location = S3Location::parse(&url)?;

--- a/src/bin/tu.rs
+++ b/src/bin/tu.rs
@@ -43,7 +43,7 @@ struct Cli {
 fn main() -> Result<()> {
     color_eyre::install()?;
     let cli = Cli::parse();
-    setup_logging(cli.verbose);
+    setup_logging(cli.verbose)?;
 
     let mut system = System::new();
     let system_memory = system.total_memory() as f32;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,11 +1,11 @@
 use log::LevelFilter;
+use color_eyre::{Report, Result, eyre::{Context, ContextCompat}};
 
-pub fn setup_logging(level: u8) {
-    fn set_log_level(local_level: LevelFilter, dep_level:  LevelFilter) {
-        let prog: String = std::env::current_exe()
-            .unwrap()
-            .file_name().unwrap()
-            .to_str().unwrap()
+pub fn setup_logging(level: u8) -> Result<(), color_eyre::eyre::Error> {
+    fn set_log_level(local_level: LevelFilter, dep_level:  LevelFilter) -> Result<(), color_eyre::eyre::Error> {
+        let prog: String = std::env::current_exe().wrap_err("Error getting current_exe")?
+            .file_name().wrap_err("File path terminated in ..")?
+            .to_str().wrap_err("utf-8 validity failed")?
             .to_owned();
 
         let crate_name = env!("CARGO_CRATE_NAME");
@@ -20,13 +20,15 @@ pub fn setup_logging(level: u8) {
 
         log::info!("Logging filter level for '{}' and '{}': {}", &prog, crate_name, local_level);
         log::info!("Dependency logging filter level: {}", dep_level);
+        Ok(())
     }
 
     match level {
-        0 => set_log_level(LevelFilter::Warn, LevelFilter::Warn),
-        1 => set_log_level(LevelFilter::Info, LevelFilter::Warn),
-        2 => set_log_level(LevelFilter::Debug, LevelFilter::Warn),
-        3 => set_log_level(LevelFilter::Trace, LevelFilter::Info),
+        0 => set_log_level(LevelFilter::Warn, LevelFilter::Warn)?,
+        1 => set_log_level(LevelFilter::Info, LevelFilter::Warn)?,
+        2 => set_log_level(LevelFilter::Debug, LevelFilter::Warn)?,
+        3 => set_log_level(LevelFilter::Trace, LevelFilter::Info)?,
         _ => panic!("Too many levels of verbosity.  You can have up to 3."),
     };
+    Ok(())
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
 use log::LevelFilter;
-use color_eyre::{Report, Result, eyre::{Context, ContextCompat}};
+use color_eyre::{Result, eyre::{Context, ContextCompat}};
 
 pub fn setup_logging(level: u8) -> Result<(), color_eyre::eyre::Error> {
     fn set_log_level(local_level: LevelFilter, dep_level:  LevelFilter) -> Result<(), color_eyre::eyre::Error> {

--- a/src/log.rs
+++ b/src/log.rs
@@ -8,12 +8,12 @@ pub fn setup_logging(level: u8) -> Result<(), color_eyre::eyre::Error> {
             .to_str().wrap_err("utf-8 validity failed")?
             .to_owned();
 
-        let crate_name = env!("CARGO_CRATE_NAME");
+        let crate_name: &'static str = env!("CARGO_CRATE_NAME");
 
         env_logger::builder()
             .filter_level(dep_level)
             .filter_module(&prog, local_level)
-            .filter_module(&crate_name, local_level)            
+            .filter_module(crate_name, local_level)            
             .init();
         println!("Logging filter level for '{}' and '{}': {}", &prog, crate_name, local_level);
         println!("Dependency logging filter level: {}", dep_level);

--- a/src/process/system.rs
+++ b/src/process/system.rs
@@ -1,30 +1,31 @@
 use std::collections::HashSet;
 
-use sysinfo::{Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System as SysInfoSystem, ThreadKind};
+use sysinfo::{
+    Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System as SysInfoSystem, ThreadKind,
+};
 
 pub struct System {
-    sys_info: SysInfoSystem
+    sys_info: SysInfoSystem,
 }
 
 impl System {
     pub fn new() -> Self {
         let mut instance = Self {
-            sys_info: SysInfoSystem::new()
+            sys_info: SysInfoSystem::new(),
         };
         instance.sys_info.refresh_all();
         instance
     }
 
     pub fn refresh_process_stats(&mut self) {
-        self.sys_info
-            .refresh_processes_specifics(
-                ProcessesToUpdate::All,
-                true,
-                ProcessRefreshKind::nothing()
-                    .with_memory()
-                    .with_cpu()
-                    .with_tasks()
-            );
+        self.sys_info.refresh_processes_specifics(
+            ProcessesToUpdate::All,
+            true,
+            ProcessRefreshKind::nothing()
+                .with_memory()
+                .with_cpu()
+                .with_tasks(),
+        );
     }
 
     pub fn total_memory(&self) -> u64 {
@@ -34,39 +35,41 @@ impl System {
     pub fn get_pid_tree_utilisation(&mut self, pid: Pid) -> CpuRamUsage {
         let children = self.get_pid_tree(pid, true);
         log::trace!("Descendants of {}: {:#?}", pid, &children);
-    
-        let usage = children.iter()
-            .filter_map(|pid|{
+
+        children
+            .iter()
+            .filter_map(|pid| {
                 let proc_opt = self.sys_info.process(*pid);
-                log::trace!("Found child: {:?}", proc_opt.map(|p|p.pid()));
+                log::trace!("Found child: {:?}", proc_opt.map(|p| p.pid()));
                 proc_opt
             })
-            .map(|proc|{
-                let usage = CpuRamUsage{
+            .map(|proc| {
+                let usage = CpuRamUsage {
                     cpu_percent: proc.cpu_usage(),
                     memory_bytes: proc.memory(),
                 };
                 log::info!("{} -> {:?}", proc.pid(), usage);
                 usage
             })
-            .sum();
-
-        usage
+            .sum()
     }
 
     pub fn get_pid_tree(&mut self, root_pid: Pid, exclude_userland: bool) -> HashSet<Pid> {
         self.refresh_process_stats();
 
-        fn find_children(pid: Pid, sys_info: &SysInfoSystem, exclude_userland: bool) -> HashSet<Pid> { 
-            let children_it = sys_info.processes()
+        fn find_children(
+            pid: Pid,
+            sys_info: &SysInfoSystem,
+            exclude_userland: bool,
+        ) -> HashSet<Pid> {
+            let children_it = sys_info
+                .processes()
                 .iter()
-                .filter(|(_pid, proc)| {
-                    proc.parent().map(|ppid| ppid == pid).unwrap_or(false)
-                });
-                
+                .filter(|(_pid, proc)| proc.parent().map(|ppid| ppid == pid).unwrap_or(false));
+
             let children_it: Box<dyn Iterator<Item = (&Pid, &Process)>> = if exclude_userland {
                 // Filter out processes in userland
-                Box::new(children_it.filter(|(_,proc)|{
+                Box::new(children_it.filter(|(_, proc)| {
                     proc.thread_kind()
                         .map(|k| k != ThreadKind::Userland)
                         .unwrap_or(true)
@@ -75,19 +78,16 @@ impl System {
                 // Keep all child processes
                 Box::new(children_it)
             };
-                
-            children_it.map(|(&pid,_)| pid)
-                .collect()
+
+            children_it.map(|(&pid, _)| pid).collect()
         }
-        
+
         let mut to_visit: Vec<Pid> = vec![root_pid];
         let mut acc: HashSet<Pid> = HashSet::new();
 
         while let Some(pid) = to_visit.pop() {
             acc.insert(pid);
-            to_visit.extend(
-                find_children(pid, &self.sys_info, exclude_userland)
-            );
+            to_visit.extend(find_children(pid, &self.sys_info, exclude_userland));
         }
 
         acc
@@ -102,8 +102,14 @@ impl System {
     }
 }
 
+impl Default for System {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(derive_more::Add, derive_more::Sum, serde::Serialize, Debug)]
-pub struct CpuRamUsage{
+pub struct CpuRamUsage {
     pub cpu_percent: f32,
     pub memory_bytes: u64,
 }

--- a/src/s3/tests.rs
+++ b/src/s3/tests.rs
@@ -1,8 +1,8 @@
-use std::{env, path::{Path, PathBuf}, process::Command};
+use std::{env, path::Path, process::Command};
 
 use aws_sdk_s3::{Client};
 use bytesize::ByteSize;
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Runtime;
 use color_eyre::{eyre::WrapErr, Result};
 
 use crate::s3::size::{Stats, VersionData};

--- a/src/s3/tests.rs
+++ b/src/s3/tests.rs
@@ -3,7 +3,7 @@ use std::{env, path::Path, process::Command};
 use aws_sdk_s3::{Client};
 use bytesize::ByteSize;
 use tokio::runtime::Runtime;
-use color_eyre::{eyre::WrapErr, Result};
+use color_eyre::{Result, eyre::{OptionExt, WrapErr}};
 
 use crate::s3::size::{Stats, VersionData};
 
@@ -160,7 +160,7 @@ fn test_with_versions() -> Result<()> {
         orphaned_vers: Stats { num_objects: 1, size: ByteSize(38) },
     };
 
-    assert_eq!(expected_versions, report.versions.expect("Report hyas no versions."));
+    assert_eq!(expected_versions, report.versions.ok_or_eyre("Report has no versions.")?);
     
     Ok(())
 }

--- a/src/s3/tests.rs
+++ b/src/s3/tests.rs
@@ -29,7 +29,7 @@ impl StorageTestHelper {
             };
 
 
-        let runtime = Runtime::new().unwrap();   
+        let runtime = Runtime::new()?;   
         let s3_wrapper = {
             let client = {
                 let config = runtime.block_on(async {aws_config::load_from_env().await});
@@ -160,7 +160,7 @@ fn test_with_versions() -> Result<()> {
         orphaned_vers: Stats { num_objects: 1, size: ByteSize(38) },
     };
 
-    assert_eq!(expected_versions, report.versions.unwrap());
+    assert_eq!(expected_versions, report.versions.expect("Report hyas no versions."));
     
     Ok(())
 }

--- a/src/s3/types.rs
+++ b/src/s3/types.rs
@@ -1,32 +1,35 @@
 use std::fmt::Display;
 
-use regex::Regex;
 use color_eyre::{Result, eyre::eyre};
+use regex::Regex;
 
-
-pub struct S3Location{
+pub struct S3Location {
     pub bucket: String,
     pub prefix: String,
 }
-impl S3Location{
-    pub fn parse(s3_location: &str) -> Result<S3Location>{
+impl S3Location {
+    pub fn parse(s3_location: &str) -> Result<S3Location> {
         let s3_path_re = Regex::new(
-                // https://regex101.com/r/wAmOQU/1
-                r#"^([Ss]3://)?(?P<bucket>[^/]*)(?P<prefix>[\w/.-]*)$"#,
-            )?;
+            // https://regex101.com/r/wAmOQU/1
+            r#"^([Ss]3://)?(?P<bucket>[^/]*)(?P<prefix>[\w/.-]*)$"#,
+        )?;
 
-            let captures = s3_path_re
-                .captures(s3_location)
-                .ok_or_else(|| eyre!("No regex matches"))?;
-            let bucket = captures.name("bucket").unwrap().as_str().to_string();
-            let prefix = captures
-                .name("prefix")
-                .unwrap()
-                .as_str();
-            let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
-            let prefix = prefix.strip_suffix('/').unwrap_or(prefix).to_string();
+        let captures = s3_path_re
+            .captures(s3_location)
+            .ok_or_else(|| eyre!("No regex matches"))?;
+        let bucket = captures
+            .name("bucket")
+            .expect("Bucket capture group found no matches.")
+            .as_str()
+            .to_string();
+        let prefix = captures
+            .name("prefix")
+            .expect("Prefix capture group found no matches.")
+            .as_str();
+        let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
+        let prefix = prefix.strip_suffix('/').unwrap_or(prefix).to_string();
 
-        Ok(S3Location{ bucket, prefix })
+        Ok(S3Location { bucket, prefix })
     }
 }
 impl Display for S3Location {

--- a/src/s3/types.rs
+++ b/src/s3/types.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use color_eyre::{Result, eyre::eyre};
+use color_eyre::{Result, eyre::{OptionExt}};
 use regex::Regex;
 
 pub struct S3Location {
@@ -16,15 +16,15 @@ impl S3Location {
 
         let captures = s3_path_re
             .captures(s3_location)
-            .ok_or_else(|| eyre!("No regex matches"))?;
+            .ok_or_eyre("No regex matches.")?;
         let bucket = captures
             .name("bucket")
-            .expect("Bucket capture group found no matches.")
+            .ok_or_eyre("Bucket capture group found no matches.")?
             .as_str()
             .to_string();
         let prefix = captures
             .name("prefix")
-            .expect("Prefix capture group found no matches.")
+            .ok_or_eyre("Prefix capture group found no matches.")?
             .as_str();
         let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
         let prefix = prefix.strip_suffix('/').unwrap_or(prefix).to_string();

--- a/src/s3/wrapper.rs
+++ b/src/s3/wrapper.rs
@@ -140,9 +140,10 @@ impl S3Wrapper {
 
             let it = delete_markers.into_iter().map(|item| {
                 ObjectIdentifier::builder()
-                .set_version_id(item.version_id)
-                .set_key(item.key)
-                .build().expect("Build error for delete markers.")
+                    .set_version_id(item.version_id)
+                    .set_key(item.key)
+                    .build()
+                    .expect("Build error for delete markers.")
             });
             object_identifiers.extend(it);
 
@@ -162,9 +163,9 @@ impl S3Wrapper {
                     .bucket(bucket)
                     .delete(
                         Delete::builder()
-                            .set_objects(Some(object_identifiers))
-                            .build()
-                            .expect("Build error for delete builder."),
+                                .set_objects(Some(object_identifiers))
+                                .build()
+                                .expect("Build error for delete builder."),
                     )
                     .send()
                     .await?;

--- a/src/s3/wrapper.rs
+++ b/src/s3/wrapper.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use aws_sdk_s3::{operation::{list_object_versions::ListObjectVersionsOutput, list_objects_v2::ListObjectsV2Output}, types::{BucketVersioningStatus, Delete, Object, ObjectIdentifier, ObjectVersion}, Client};
 use human_format::Formatter;
 
-use color_eyre::{Result, eyre::OptionExt};
+use color_eyre::{Result, eyre::{Context, OptionExt}};
 
 
 pub struct S3Wrapper {
@@ -165,8 +165,8 @@ impl S3Wrapper {
                         Delete::builder()
                                 .set_objects(Some(object_identifiers))
                                 .build()
-                                .expect("Build error for delete builder."),
-                    )
+                                .wrap_err("Build error on Delete::builder")?
+                        )
                     .send()
                     .await?;
             } else {

--- a/src/s3/wrapper.rs
+++ b/src/s3/wrapper.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use aws_sdk_s3::{operation::{list_object_versions::ListObjectVersionsOutput, list_objects_v2::ListObjectsV2Output}, types::{BucketVersioningStatus, Delete, Object, ObjectIdentifier, ObjectVersion}, Client};
 use human_format::Formatter;
 
-use color_eyre::{Result, eyre::{Context, OptionExt}};
+use color_eyre::{Result, eyre::OptionExt};
 
 
 pub struct S3Wrapper {


### PR DESCRIPTION
Cleaned unwraps where possible. Where I was unable to use eyre used expect with message (mostly in `.map(..)`.

I have left `unwrap_or_default()` for S3 api assuming these are correct?
```
s3/wrapper.rs
18:                page.versions.unwrap_or_default())
138:            let object_versions = page.versions.unwrap_or_default();
139:            let delete_markers = page.delete_markers.unwrap_or_default();
```


Not a big fan of these but they are inside `map(...)` there might be a better way than expect?
```
s3/wrapper.rs
145:                .build().expect("Build error for delete markers.")
154:                    .expect("Build error for object versions.")
167:                            .expect("Build error for delete builder."),
```

```
s3/size.rs
18:        let size = ByteSize::b(items.iter().map(|o|o.borrow().size.expect("Object has no size.")).sum::<i64>() as u64);
26:        let size = ByteSize::b(items.iter().map(|o|o.borrow().size.expect("Object has no size.")).sum::<i64>() as u64);
```

unsure about logic here:
```
s3/size.rs
128:        let (current, orphaned): (Vec<_>, Vec<_>) = versions.iter()
                  .filter(|t|!t.is_latest.expect("S3 API issue is_latest unpopulated."))
                  .partition(|t|{
                      t.key().map(|k|current_object_keys.contains(k)).expect("S3 API issue No key for object.")
            });
```